### PR TITLE
docs(fix): `PyInvoke` replaced by `just`

### DIFF
--- a/README.md
+++ b/README.md
@@ -913,7 +913,8 @@ This package provides a simple deterministic strategy implemented in `src/[packa
 
 A DAG can express the dependencies between steps while keeping the individual step independent.
 
-This package provides a simple DAG example in `tasks/dags.py`. This approach is based on [PyInvoke](https://www.pyinvoke.org/).
+This package provides a simple DAG example in `tasks/project.just`. This approach is based on [Just](https://just.systems/man/en/introduction.html) and explained
+in the section on Automation above.
 
 In production, we recommend to use a scalable system such as [Airflow](https://airflow.apache.org/), [Dagster](https://dagster.io/), [Prefect](https://www.prefect.io/), [Metaflow](https://metaflow.org/), or [ZenML](https://zenml.io/).
 

--- a/README.md
+++ b/README.md
@@ -913,8 +913,7 @@ This package provides a simple deterministic strategy implemented in `src/[packa
 
 A DAG can express the dependencies between steps while keeping the individual step independent.
 
-This package provides a simple DAG example in `tasks/project.just`. This approach is based on [Just](https://just.systems/man/en/introduction.html) and explained
-in the section on Automation above.
+This package provides a DAG example in `tasks/project.just`. The approach is based on [Just](https://just.systems/man/en/introduction.html) and is explained in the section on Automation above.
 
 In production, we recommend to use a scalable system such as [Airflow](https://airflow.apache.org/), [Dagster](https://dagster.io/), [Prefect](https://www.prefect.io/), [Metaflow](https://metaflow.org/), or [ZenML](https://zenml.io/).
 


### PR DESCRIPTION


# Changes
update the section on DAGs in README.md reflecting the replacement of `PyInvoke` by `just`

# Reasons
Brings the readme up to date in this minor point

# Impacts
Only the documentation

# Notes
This is my first little contribution. Just offering, in case you accept external PRs.
Either way, many thanks for this great project!
