### PR TITLE
docs(readme): Add Pytest Cov as an alternative for code coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ Edition, validation, and versioning of your project source code.
 - **Limitations**:
   - None
 - **Alternatives**:
-  - None?
+  - [Pytest Cov](https://pytest-cov.readthedocs.io/en/latest/) Simple code coverage package for users leveraging Pytest to run tests.
 
 ### Editor: [VS Code](https://code.visualstudio.com/)
 

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ Edition, validation, and versioning of your project source code.
 - **Limitations**:
   - None
 - **Alternatives**:
-  - [Pytest Cov](https://pytest-cov.readthedocs.io/en/latest/) Simple code coverage package for users leveraging Pytest to run tests.
+-  - [Pytest Cov](https://pytest-cov.readthedocs.io/en/latest/) A Pytest plugin that uses `coverage.py` to measure code coverage.
 
 ### Editor: [VS Code](https://code.visualstudio.com/)
 


### PR DESCRIPTION
# Changes
- Updates readme with Pytest Cov as an alternative for code coverage.

# Reasons
- I use this plugin in my day job, it works great for basic runtime code coverage. You just need to configure a few args in your pytest cofiguration.

# Testing
N/A

# Impacts
N/A

# Notes
N/A